### PR TITLE
Broken pipe

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::io::{BufRead, BufWriter, ErrorKind, StdoutLock, Write};
+use std::io::{BufRead, BufWriter, ErrorKind, Write};
 
 use anyhow::{Context, Error, Result};
 use regex::{Regex, RegexSet};
@@ -41,7 +41,7 @@ struct Source<'a> {
     reader: Box<dyn BufRead>,
 }
 
-type Sink<'a> = BufWriter<StdoutLock<'a>>;
+type Sink = BufWriter<dyn Write>;
 
 impl Handler {
     pub(crate) fn run(&self) -> Result<Exit> {
@@ -88,7 +88,7 @@ impl Handler {
                     file_started = true;
                 }
                 if file_started && self.is_match(&record) {
-                    let mut r = if self.filename {
+                    let r = if self.filename {
                         with_filename(sink, &record, source.filename)
                     } else {
                         without_filename(sink, &record)

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,11 +1,11 @@
 use std::io::BufRead;
 
-use anyhow::Context;
+use anyhow::{Context, Result};
 use compress_io::compress::CompressIo;
 
 pub(crate) const STD_IN_FILENAME: &str = "-";
 
-pub fn get_reader(filename: &String) -> anyhow::Result<Box<dyn BufRead>> {
+pub fn get_reader(filename: &String) -> Result<Box<dyn BufRead>> {
     Ok(if filename == STD_IN_FILENAME {
         Box::new(
             CompressIo::new() // implicitly STDIN

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,30 +4,37 @@ use clap::{CommandFactory, Parser};
 use cli::Cli;
 
 use crate::handler::Handler;
+use crate::Exit::Help;
 
 mod cli;
 mod handler;
 mod io;
 
+#[derive(Eq, PartialEq)]
+pub enum Exit {
+    Help,
+    Error,
+    Terminate,
+    NoMatch,
+    Match,
+}
+
 /// Run the grep, returning how many records matched.
-pub fn run() -> Result<isize> {
+pub fn run() -> Result<Exit> {
     let args = Cli::parse();
     // if no-filename (-h) without any patterns
     if args.no_filename && !args.has_patterns() {
         Cli::command()
             .print_help()
             .with_context(|| "failed to print help")?;
-        Ok(-1)
+        Ok(Help)
     } else if args.help {
         Cli::command()
             .print_long_help()
             .with_context(|| "failed to print long help")?;
-        Ok(-1)
+        Ok(Help)
     } else {
         let handler: Handler = args.into();
-        match handler.run() {
-            Ok(n) => Ok(n as isize),
-            Err(e) => Err(e),
-        }
+        handler.run()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod cli;
 mod handler;
 mod io;
 
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Debug)]
 pub enum Exit {
     Help,
     Error,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,17 @@
 use std::process;
 
+use lgrep::Exit;
+
 fn main() {
     match lgrep::run() {
         Err(e) => {
-            eprintln!("Application error: {e}");
+            eprintln!("lgrep error: {e}");
             process::exit(2);
         }
-        Ok(-1) => process::exit(2),
-        Ok(matches) => process::exit(if matches > 0 { 0 } else { 1 }),
+        Ok(Exit::Help) => process::exit(2),
+        Ok(Exit::Error) => process::exit(2),
+        Ok(Exit::Terminate) => process::exit(3),
+        Ok(Exit::NoMatch) => process::exit(1),
+        Ok(Exit::Match) => process::exit(0),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,13 @@
-use std::process;
+use std::process::ExitCode;
 
 use lgrep::Exit;
 
-fn main() {
+fn main() -> ExitCode {
     match lgrep::run() {
         Err(e) => {
-            eprintln!("lgrep error: {e}");
-            process::exit(2);
+            eprintln!("lgrep: {e:#}");
+            Exit::Error.into()
         }
-        Ok(Exit::Help) => process::exit(2),
-        Ok(Exit::Error) => process::exit(2),
-        Ok(Exit::Terminate) => process::exit(3),
-        Ok(Exit::NoMatch) => process::exit(1),
-        Ok(Exit::Match) => process::exit(0),
+        Ok(e) => e.into(),
     }
 }


### PR DESCRIPTION
When STDOUT is closed while searching, gracefully terminate without printing an IO error. Exit status is tracked explicitly to support this. And buffer the output stream, flushing per record.

closes #1 