### PR TITLE
support --count option

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -15,8 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - name: Build.
+        run: cargo build --verbose
+      - name: Test.
+        run: cargo test --verbose
+      - name: Proper formatting!
+        run: cargo fmt --all -- --check
+      - name: No Dirtiness!
+        run: git diff --exit-code

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,10 +8,13 @@ use regex::Regex;
     author,
     arg_required_else_help = true,
     disable_help_flag = true,
-    long_about = "A grep-like tool for log files with multi-line records. Files (and STDIN) will be \
-                  automatically decompressed, assuming appropriate utilities are available on your \
-                  $PATH.",
-    after_long_help = "Environment:
+    after_long_help = "COMPRESSED LOGS:
+\n\
+                       Files (and STDIN) will be automatically decompressed, assuming appropriate \
+                       utilities are available on your $PATH. That is, 'gzcat log.gz | lgrep ERROR' \
+                       is unneeded; just do 'lgrep ERROR log.gz' (but don't do 'zlgrep ERROR log.gz').
+\n\
+                       ENVIRONMENT:
 \n\
                        The LGREP_LOG_PATTERN environment variable may be used to default the \
                        '--log-pattern' option, if you consistently need a different start-of-record \
@@ -57,6 +60,10 @@ pub(crate) struct Cli {
                      impact log/start/end patterns, only the main matching pattern(s)."
     )]
     pub invert_match: bool,
+
+    /// Only a count of selected records is written to standard output.
+    #[arg(short, long)]
+    pub count: bool,
 
     /// Label to use in place of “(standard input)” for a file name where a file name would normally be printed.
     #[arg(long)]
@@ -140,6 +147,7 @@ mod tests {
                 max_count: None,
                 invert_match: false,
                 label: None,
+                count: false,
                 log_pattern: None,
                 start: None,
                 end: None,

--- a/src/io.rs
+++ b/src/io.rs
@@ -3,10 +3,10 @@ use std::io::BufRead;
 use anyhow::{Context, Result};
 use compress_io::compress::CompressIo;
 
-pub(crate) const STD_IN_FILENAME: &str = "-";
+pub(crate) const STDIN_FILENAME: &str = "-";
 
 pub fn get_reader(filename: &String) -> Result<Box<dyn BufRead>> {
-    Ok(if filename == STD_IN_FILENAME {
+    Ok(if filename == STDIN_FILENAME {
         Box::new(
             CompressIo::new() // implicitly STDIN
                 .bufreader()


### PR DESCRIPTION
Add support for -c/--count option, per standard grep, though emitting _record_ counts, not _line_ counts.

Also add format/dirtiness checks to the CI action.

Closes #3 