### PR TITLE
No implicit pattern w/ explicit patterns

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -216,7 +216,9 @@ impl From<Cli> for Handler {
     fn from(cli: Cli) -> Self {
         let mut patterns = cli.patterns;
         if let Some(p) = cli.pattern {
-            patterns.push(p);
+            if let Ok(re) = p.parse() {
+                patterns.push(re);
+            }
         }
         let mut pattern_strings = patterns.iter().map(|p| p.to_string()).collect::<Vec<_>>();
         let mut log_pattern = cli.log_pattern.unwrap_or_else(default_log_pattern);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ impl From<Exit> for ExitCode {
 
 /// Run the grep, returning how many records matched.
 pub fn run() -> Result<Exit> {
-    let args = Cli::parse();
+    let args = Cli::parse().like_grep();
     // if no-filename (-h) without any patterns
     if args.no_filename && !args.has_patterns() {
         Cli::command()


### PR DESCRIPTION
When one or more explicit patterns are passed with `-e`, all positional parameters are treated as filenames. With zero `-e`, the first positional parameter is treated as a pattern, and the rest as filenames.

Closes #11 