### PR TITLE
Older glibc

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -40,8 +40,16 @@ jobs:
         platform:
           - macos-13 # x86_64
           - macos-14 # arm64
-          - ubuntu-latest
+          - ubuntu-latest # currently glibc 2.35
+          - ubuntu-20.04 # glibc 2.31
           - windows-latest
+        include:
+          - binary: target/release/lgrep
+          - label_suffix: ""
+          - platform: windows-latest
+            binary: target\release\lgrep.exe
+          - platform: ubuntu-20.04
+            label_suffix: -glibc2.31
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout.
@@ -54,11 +62,15 @@ jobs:
         id: build
         shell: bash
         run: |
+          echo "platform     = ${{ matrix.platform }}"
+          which gcc && (echo '#include <errno.h>' | gcc -xc - -E -dM | grep -E '^#define __GLIBC(_MINOR)?__ ') || echo "not glibc..."
+          echo "binary       = ${{ matrix.binary }}"
+          echo "label_suffix = ${{ matrix.label_suffix }}"
           cargo run --release --quiet -- --version
           echo "version=`cargo run --release --quiet -- --version | cut -d ' ' -f 2`" >> "$GITHUB_OUTPUT"
       - name: Upload Release Binary.
         uses: actions/upload-artifact@v4
         if: startsWith(github.ref, 'refs/heads/release/')
         with:
-          name: lgrep-${{ steps.build.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
-          path: ${{ runner.os == 'Windows' && 'target\release\lgrep.exe' || 'target/release/lgrep' }}
+          name: lgrep-${{ steps.build.outputs.version }}-${{ runner.os }}-${{ runner.arch }}${{ matrix.label_suffix }}
+          path: ${{ matrix.binary }}

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -19,7 +19,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout.
+        uses: actions/checkout@v4
       - name: Build.
         run: cargo build --verbose
       - name: Test.
@@ -43,13 +44,16 @@ jobs:
           - windows-latest
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Build/Test Release Binary.
+      - name: Checkout.
+        uses: actions/checkout@v4
+      - name: Build.
+        run: cargo build --release --verbose
+      - name: Test.
+        run: cargo test --release --verbose
+      - name: Execute.
         id: build
         shell: bash
         run: |
-          cargo build --release --verbose
-          cargo test --release --verbose
           cargo run --release --quiet -- --version
           echo "version=`cargo run --release --quiet -- --version | cut -d ' ' -f 2`" >> "$GITHUB_OUTPUT"
       - name: Upload Release Binary.
@@ -57,4 +61,4 @@ jobs:
         if: startsWith(github.ref, 'refs/heads/release/')
         with:
           name: lgrep-${{ steps.build.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
-          path: ${{ runner.os == 'Windows' && 'target\release\lgrep' || 'target/release/lgrep' }}
+          path: ${{ runner.os == 'Windows' && 'target\release\lgrep.exe' || 'target/release/lgrep' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lgrep"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "A grep-like tool for log files with multi-line records"
 authors = [
     "Barney Boisvert <bboisvert@gmail.com>"
 ]
-version = "1.2.1"
+version = "1.3.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Build Linux binaries on Ubuntu 20 as well as latest, to support systems with older versions of `glibc` on them.