### PR TITLE
Newline handling

### DIFF
--- a/src/handler/handler_tests.rs
+++ b/src/handler/handler_tests.rs
@@ -279,7 +279,7 @@ three
 four",
     );
     assert_eq!(
-        vec!["spiffy.txt:one\n", "spiffy.txt:two\n", "spiffy.txt:four",],
+        vec!["spiffy.txt:one\n", "spiffy.txt:two\n", "spiffy.txt:four\n",],
         mac.records
     );
     assert_eq!(3, mac.flush_count);
@@ -303,7 +303,7 @@ two
 three
 four",
     );
-    assert_eq!(vec!["spiffy.txt:3:three\nspiffy.txt-4-four"], mac.records);
+    assert_eq!(vec!["spiffy.txt:3:three\nspiffy.txt-4-four\n"], mac.records);
     assert_eq!(1, mac.flush_count);
     assert_eq!(Some(Exit::Match), mac.exit);
 }
@@ -329,7 +329,8 @@ four'n'stuff",
     assert_eq!(
         vec![
         "\u{1b}[35mspiffy.txt\u{1b}[0m\u{1b}[36m:\u{1b}[0m\u{1b}[32m3\u{1b}[0m\u{1b}[36m:\u{1b}[0mth\u{1b}[1m\u{1b}[31mr\u{1b}[0mee
-\u{1b}[35mspiffy.txt\u{1b}[0m\u{1b}[36m-\u{1b}[0m\u{1b}[32m4\u{1b}[0m\u{1b}[36m-\u{1b}[0mfou\u{1b}[1m\u{1b}[31mr\u{1b}[0m'n'stuff"],
+\u{1b}[35mspiffy.txt\u{1b}[0m\u{1b}[36m-\u{1b}[0m\u{1b}[32m4\u{1b}[0m\u{1b}[36m-\u{1b}[0mfou\u{1b}[1m\u{1b}[31mr\u{1b}[0m'n'stuff
+"],
         mac.records
     );
     assert_eq!(1, mac.flush_count);

--- a/src/read/lines.rs
+++ b/src/read/lines.rs
@@ -41,6 +41,9 @@ impl Iterator for Lines {
                     self.eof = true;
                     return None;
                 }
+                if text.ends_with('\n') {
+                    text.pop();
+                }
                 self.line_num += 1;
                 Some(Ok(Line {
                     text,
@@ -79,8 +82,8 @@ mod test {
             .collect();
         assert_eq!(
             vec![
-                Line::new("one\n", 1),
-                Line::new("two\n", 2),
+                Line::new("one", 1),
+                Line::new("two", 2),
                 Line::new("three", 3),
             ],
             lines

--- a/src/read/records.rs
+++ b/src/read/records.rs
@@ -39,6 +39,7 @@ pub(crate) struct Record {
 
 impl Record {
     pub(crate) fn push_line(&mut self, line: &Line) {
+        self.text.push('\n');
         self.text.push_str(&line.text);
     }
 }
@@ -118,8 +119,8 @@ mod test {
         let re = Regex::new("o").unwrap();
         assert_eq!(
             vec![
-                Record::new("one\nzzzz\n", 1, 1),
-                Record::new("two\nthree\n", 2, 3),
+                Record::new("one\nzzzz", 1, 1),
+                Record::new("two\nthree", 2, 3),
                 Record::new("four\nfive", 3, 5),
             ],
             to_records(
@@ -137,10 +138,10 @@ four\nfive",
         let re = Regex::new(r"LOG").unwrap();
         assert_eq!(
             vec![
-                Record::new("one, thee father\n", 1, 1),
-                Record::new("two, thee mother\n", 2, 2),
-                Record::new("LOG: three\nfour\n", 3, 3),
-                Record::new("LOG: five\nsix\n", 4, 5),
+                Record::new("one, thee father", 1, 1),
+                Record::new("two, thee mother", 2, 2),
+                Record::new("LOG: three\nfour", 3, 3),
+                Record::new("LOG: five\nsix", 4, 5),
             ],
             to_records(
                 "one, thee father

--- a/src/write.rs
+++ b/src/write.rs
@@ -63,7 +63,7 @@ impl<'a> LgrepWrite<'a> {
             !self.line_numbers,
             "line numbers and counts together makes no sense"
         );
-        self.spew(filename, &format!("{count}\n"), 0)
+        self.spew(filename, &count.to_string(), 0)
     }
 
     pub(crate) fn write_record_with_matches(
@@ -119,7 +119,7 @@ impl<'a> LgrepWrite<'a> {
         text: &str,
         first_line: usize,
     ) -> std::io::Result<()> {
-        let lines = text.split_inclusive('\n');
+        let lines = text.split('\n');
         let mut separator = ':';
         let mut line_num = first_line;
         for l in lines {
@@ -142,7 +142,7 @@ impl<'a> LgrepWrite<'a> {
                     write!(self.sink, "{separator}")?;
                 }
             }
-            write!(self.sink, "{l}")?;
+            writeln!(self.sink, "{l}")?;
             if self.sink.buffer().len() >= FLUSH_BUFFER_AT {
                 self.sink.flush()?
             }


### PR DESCRIPTION
Remove newlines as lines are read in, and add them back when writing results out. This makes `$` work more reasonably, particularly for `--log-pattern`.