### PR TITLE
Multi line match color

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,7 +92,7 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub label: Option<String>,
 
-    /// Color output, according to a subset of `GREP_COLOR`.
+    /// Color output, according to a subset of `GREP_COLORS`.
     ///
     /// Surround the matched (non-empty) strings and file names with escape sequences to display
     /// them in color on the terminal. The colors are defined by the environment variable

--- a/src/handler/handler_tests.rs
+++ b/src/handler/handler_tests.rs
@@ -338,6 +338,33 @@ four'n'stuff",
 }
 
 #[test]
+fn color_multiline_match() {
+    let handler = Handler {
+        pattern_set: Regex::new(r"XXX\nYYY").unwrap(),
+        log_pattern: Regex::new(r"e").unwrap(),
+        color_mode: ColorChoice::Always,
+        ..Handler::empty()
+    };
+    let mac = MatchesAndCount::run(
+        &handler,
+        "one
+two
+threeXXX
+YYYfour",
+    );
+    assert_eq!(
+        vec![
+            "three\u{1b}[1m\u{1b}[31mXXX\u{1b}[0m
+\u{1b}[1m\u{1b}[31mYYY\u{1b}[0mfour
+"
+        ],
+        mac.records
+    );
+    assert_eq!(1, mac.flush_count);
+    assert_eq!(Some(Exit::Match), mac.exit);
+}
+
+#[test]
 fn filenames_final_newline() {
     let handler = Handler {
         pattern_set: Regex::new(r"r").unwrap(),

--- a/src/read/records.rs
+++ b/src/read/records.rs
@@ -61,9 +61,9 @@ impl<'a> Iterator for Records<'a> {
                     self.before_first_record = false;
                 }
                 Record {
-                    text: l.text.to_owned(),
                     record_num: self.record_num,
                     first_line: l.line_num,
+                    text: l.text,
                 }
             }
         };

--- a/src/write.rs
+++ b/src/write.rs
@@ -81,7 +81,13 @@ impl<'a> LgrepWrite<'a> {
                     if m.start() > thru {
                         text.push_str(&record.text[thru..m.start()]);
                     }
-                    text.push_str(&format!("{}{}{0:#}", s, &record.text[m.start()..m.end()]));
+                    for line in record.text[m.start()..m.end()].split_inclusive('\n') {
+                        if let Some(bare_line) = line.strip_suffix('\n') {
+                            text.push_str(&format!("{}{}{0:#}\n", s, bare_line));
+                        } else {
+                            text.push_str(&format!("{}{}{0:#}", s, line));
+                        }
+                    }
                     thru = m.end();
                 }
                 if thru < record.text.len() {


### PR DESCRIPTION
When coloring multi-line matches, add the controller characters line-by-line, so they don't interact with filenames and line numbers (if present).